### PR TITLE
fix(extends): baseUrl that points to parent path

### DIFF
--- a/src/utils/read-tsconfig.ts
+++ b/src/utils/read-tsconfig.ts
@@ -39,7 +39,7 @@ export function readTsconfig(
 			compilerOptions.baseUrl = path.relative(
 				directoryPath,
 				path.join(path.dirname(extendsPath), compilerOptions.baseUrl!),
-			);
+			) || './';
 		}
 
 		if (extendsConfig.files) {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,8 +1,8 @@
 import { describe } from 'manten';
 
 describe('get-tsconfig', ({ runTestSuite }) => {
-	// runTestSuite(import('./specs/errors.spec'));
-	// runTestSuite(import('./specs/finds-config.spec'));
+	runTestSuite(import('./specs/errors.spec'));
+	runTestSuite(import('./specs/finds-config.spec'));
 	runTestSuite(import('./specs/extends.spec'));
-	// runTestSuite(import('./specs/paths.spec'));
+	runTestSuite(import('./specs/paths.spec'));
 });

--- a/tests/specs/extends.spec.ts
+++ b/tests/specs/extends.spec.ts
@@ -550,8 +550,6 @@ export default testSuite(({ describe }) => {
 				const fixture = await createFixture({
 					'src-a': {
 						'a.ts': '',
-						'b.ts': '',
-						'c.ts': '',
 					},
 					'tsconfig.json': tsconfigJson({
 						compilerOptions: {
@@ -575,8 +573,6 @@ export default testSuite(({ describe }) => {
 					project: {
 						'src-a': {
 							'a.ts': '',
-							'b.ts': '',
-							'c.ts': '',
 						},
 						'tsconfig.json': tsconfigJson({
 							compilerOptions: {
@@ -587,6 +583,28 @@ export default testSuite(({ describe }) => {
 					'tsconfig.json': tsconfigJson({
 						extends: './project/tsconfig.json',
 					}),
+				});
+
+				const expectedTsconfig = await getTscConfig(fixture.path);
+				delete expectedTsconfig.files;
+
+				const tsconfig = getTsconfig(fixture.path);
+				expect(tsconfig!.config).toStrictEqual(expectedTsconfig);
+
+				await fixture.cleanup();
+			});
+
+			test('resolves parent baseUrl path', async () => {
+				const fixture = await createFixture({
+					'project/tsconfig.json': tsconfigJson({
+						compilerOptions: {
+							baseUrl: '..',
+						},
+					}),
+					'tsconfig.json': tsconfigJson({
+						extends: './project/tsconfig.json',
+					}),
+					'a.ts': '',
 				});
 
 				const expectedTsconfig = await getTscConfig(fixture.path);

--- a/tests/specs/paths.spec.ts
+++ b/tests/specs/paths.spec.ts
@@ -107,6 +107,37 @@ export default testSuite(({ describe }) => {
 			]);
 		});
 
+		test('baseUrl from extends', async () => {
+			const fixture = await createFixture({
+				'some-dir/tsconfig.json': tsconfigJson({
+					compilerOptions: {
+						baseUrl: '..',
+						paths: {
+							$lib: [
+								'src/lib',
+							],
+							'$lib/*': [
+								'src/lib/*',
+							],
+						},
+					},
+				}),
+				'tsconfig.json': tsconfigJson({
+					extends: './some-dir/tsconfig.json',
+				}),
+			});
+
+			const tsconfig = getTsconfig(fixture.path);
+			expect(tsconfig).not.toBeNull();
+
+			const matcher = createPathsMatcher(tsconfig!)!;
+
+			expect(matcher).not.toBeNull();
+			expect(matcher('$lib')).toStrictEqual([
+				path.join(fixture.path, 'src/lib'),
+			]);
+		});
+
 		test('exact match', async () => {
 			const fixture = await createFixture({
 				'tsconfig.json': tsconfigJson({


### PR DESCRIPTION
## Problem

When `a` and `b` in `path.relative(a, b)` resolve to the same path, `path.relative()` returns an empty string instead of `.` or `./`. This caused `baseUrl` to appear undefined.

closes https://github.com/esbuild-kit/esm-loader/issues/26

## Changes

When `path.relative()` return an empty string, fall back to `./`.