### PR TITLE
chore(deps): added type-fest to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
 		"pretest": "npm run build",
 		"test": "tsx tests"
 	},
+    "dependencies": {
+	    "type-fest": "^2.13.1"
+	},
 	"devDependencies": {
 		"@pvtnbr/eslint-config": "^0.22.0",
 		"@types/node": "^17.0.41",


### PR DESCRIPTION
First of all congrats. This is very useful.

I'd like to add a dependency on type-fest imported from https://github.com/privatenumber/get-tsconfig/blob/a107c720daa5045426eef70df2601daac6defd0f/src/types.ts#L1.

I know that this lib is zero-deps :smile: ... and there's other options I can propose if it's a blocker.

**What would it fix ?**

- Experience with different packages managers will work better (pnpm, yarn pnp). Future is going strict
- I have typescript issues regarding paths fixed in the latest `TsConfigJson`. See https://github.com/sindresorhus/type-fest/releases/tag/v2.13.1. Without stating the dep, resolution algorithm fallbacks to what is present... No real control of versions there.

<details>
<summary>Example of yarn why type-fest</summary>

```
yarn why type-fest
├─ @belgattitude/base-ui@workspace:packages/base-ui
│  └─ type-fest@npm:2.13.1 (via npm:^2.13.0)
│
├─ @contentlayer/core@npm:0.2.5
│  └─ type-fest@npm:2.13.1 (via npm:^2.12.2)
│
├─ @contentlayer/core@npm:0.2.5 [0efb3]
│  └─ type-fest@npm:2.13.1 (via npm:^2.12.2)
│
├─ @contentlayer/utils@npm:0.2.5
│  └─ type-fest@npm:2.13.1 (via npm:^2.12.2)
│
├─ @contentlayer/utils@npm:0.2.5 [0efb3]
│  └─ type-fest@npm:2.13.1 (via npm:^2.12.2)
│
├─ ansi-escapes@npm:4.3.2
│  └─ type-fest@npm:0.21.3 (via npm:^0.21.3)
│
├─ globals@npm:13.15.0
│  └─ type-fest@npm:0.20.2 (via npm:^0.20.2)
│
├─ meow@npm:6.1.1
│  └─ type-fest@npm:0.13.1 (via npm:^0.13.1)
│
├─ meow@npm:8.1.2
│  └─ type-fest@npm:0.18.1 (via npm:^0.18.0)
│
├─ read-pkg-up@npm:7.0.1
│  └─ type-fest@npm:0.8.1 (via npm:^0.8.1)
│
├─ read-pkg@npm:5.2.0
│  └─ type-fest@npm:0.6.0 (via npm:^0.6.0)
│
└─ website@workspace:apps/website
   └─ type-fest@npm:2.13.1 (via npm:2.13.1)
```

</details>

**Alternatives**

- [ ] To avoid adding a dep, keep a local version of `TsConfigJson`
- [ ] Add to peerDependencies (not optional in this sepcific case). It changes the way to install too.
- [ ] Others ?


Let me know. 
  