### PR TITLE
fix(types): compilerOptions.paths to require values

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"pkgroll": "^1.3.1",
 		"slash": "^4.0.0",
 		"tsx": "^3.4.2",
-		"type-fest": "^2.13.0",
+		"type-fest": "^2.13.1",
 		"typescript": "^4.7.3"
 	},
 	"eslintConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ specifiers:
   pkgroll: ^1.3.1
   slash: ^4.0.0
   tsx: ^3.4.2
-  type-fest: ^2.13.0
+  type-fest: ^2.13.1
   typescript: ^4.7.3
 
 devDependencies:
@@ -25,7 +25,7 @@ devDependencies:
   pkgroll: 1.3.1_typescript@4.7.3
   slash: 4.0.0
   tsx: 3.4.2
-  type-fest: 2.13.0
+  type-fest: 2.13.1
   typescript: 4.7.3
 
 packages:
@@ -3181,8 +3181,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /type-fest/2.13.0:
-    resolution: {integrity: sha512-lPfAm42MxE4/456+QyIaaVBAwgpJb6xZ8PRu09utnhPdWwcyj9vgy6Sq0Z5yNbJ21EdxB5dRU/Qg8bsyAMtlcw==}
+  /type-fest/2.13.1:
+    resolution: {integrity: sha512-hXYyrPFwETT2swFLHeoKtJrvSF/ftG/sA15/8nGaLuaDGfVAaq8DYFpu4yOyV4tzp082WqnTEoMsm3flKMI2FQ==}
     engines: {node: '>=12.20'}
     dev: true
 


### PR DESCRIPTION
Update type-fest to latest to fix typing issue regarding paths.

https://github.com/sindresorhus/type-fest/pull/404

As an example of what it fixes (look for the `// @ts-ignore`):

```typescript
const getTsConfigBasePaths = (tsConfigFile) => {
  const parsedTsConfig = getTsconfig(tsConfigFile);
  if (parsedTsConfig === null) {
    throw new Error(`Cannot find tsconfig file: ${tsConfigFile}`);
  }
  const tsPaths = parsedTsConfig.config.compilerOptions?.paths ?? {};

  return Object.entries(tsPaths).length > 0
    ? // @ts-ignore
      pathsToModuleNameMapper(tsPaths, {
        prefix: '<rootDir>/',
      })
    : {};
};
```

PS: added a manual patch to see if it works: https://github.com/belgattitude/perso/pull/365/files