### PR TITLE
fix: handle compilerOptions.outDir

### DIFF
--- a/src/parse-tsconfig/index.ts
+++ b/src/parse-tsconfig/index.ts
@@ -87,10 +87,21 @@ export function parseTsconfig(
 		config = merged;
 	}
 
-	if (config.compilerOptions?.baseUrl) {
+	if (config.compilerOptions) {
 		const { compilerOptions } = config;
 
-		compilerOptions.baseUrl = normalizePath(compilerOptions.baseUrl!);
+		if (compilerOptions.baseUrl) {
+			compilerOptions.baseUrl = normalizePath(compilerOptions.baseUrl);
+		}
+
+		if (compilerOptions.outDir) {
+			if (!Array.isArray(config.exclude)) {
+				config.exclude = [];
+			}
+
+			config.exclude.push(compilerOptions.outDir);
+			compilerOptions.outDir = normalizePath(compilerOptions.outDir);
+		}
 	}
 
 	if (config.files) {

--- a/src/paths-matcher/index.ts
+++ b/src/paths-matcher/index.ts
@@ -1,12 +1,12 @@
 import path from 'path';
 import slash from 'slash';
 import type { TsConfigResult } from '../types';
+import { isRelativePathPattern } from '../utils/is-relative-path-pattern';
 import {
 	assertStarCount,
 	parsePattern,
 	isPatternMatch,
 } from './utils';
-import { isRelativePathPattern } from '../utils/is-relative-path-pattern';
 import type { StarPattern, PathEntry } from './types';
 
 function parsePaths(

--- a/src/paths-matcher/index.ts
+++ b/src/paths-matcher/index.ts
@@ -3,10 +3,10 @@ import slash from 'slash';
 import type { TsConfigResult } from '../types';
 import {
 	assertStarCount,
-	isRelativePathPattern,
 	parsePattern,
 	isPatternMatch,
 } from './utils';
+import { isRelativePathPattern } from '../utils/is-relative-path-pattern';
 import type { StarPattern, PathEntry } from './types';
 
 function parsePaths(

--- a/src/paths-matcher/utils.ts
+++ b/src/paths-matcher/utils.ts
@@ -1,7 +1,5 @@
 import type { StarPattern } from './types';
 
-export const isRelativePathPattern = /^\.{1,2}(\/.*)?$/;
-
 const starPattern = /\*/g;
 
 export const assertStarCount = (

--- a/src/utils/is-relative-path-pattern.ts
+++ b/src/utils/is-relative-path-pattern.ts
@@ -1,0 +1,1 @@
+export const isRelativePathPattern = /^\.{1,2}(\/.*)?$/;

--- a/src/utils/normalize-path.ts
+++ b/src/utils/normalize-path.ts
@@ -1,7 +1,8 @@
 import slash from 'slash';
+import { isRelativePathPattern } from './is-relative-path-pattern';
 
 export const normalizePath = (filePath: string) => slash(
-	/^[./]/.test(filePath)
+	isRelativePathPattern.test(filePath)
 		? filePath
 		: `./${filePath}`,
 );

--- a/tests/specs/get-tsconfig/parses.spec.ts
+++ b/tests/specs/get-tsconfig/parses.spec.ts
@@ -24,7 +24,7 @@ export default testSuite(({ describe }) => {
 						module: 'esnext',
 						esModuleInterop: true,
 						declaration: true,
-						// outDir: 'dist',
+						outDir: 'dist',
 						strict: true,
 						target: 'esnext',
 					},


### PR DESCRIPTION
`outDir` must be added to `exclude` and normalized