### PR TITLE
refactor: move `exports.types` to top

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",
 	"exports": {
+		"types": "./dist/index.d.ts",
 		"require": "./dist/index.js",
-		"import": "./dist/index.mjs",
-		"types": "./dist/index.d.ts"
+		"import": "./dist/index.mjs"
 	},
 	"imports": {
 		"#get-tsconfig": {


### PR DESCRIPTION
Reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing