### PR TITLE
fix: resolve `paths` from tsconfig that defined it

### DIFF
--- a/src/parse-tsconfig/index.ts
+++ b/src/parse-tsconfig/index.ts
@@ -5,6 +5,7 @@ import { normalizePath } from '../utils/normalize-path.js';
 import { readJsonc } from '../utils/read-jsonc.js';
 import { realpath } from '../utils/fs-cached.js';
 import { resolveExtendsPath } from './resolve-extends-path.js';
+import { implicitBaseUrlSymbol } from '../utils/symbols.js';
 
 const resolveExtends = (
 	extendsPath: string,
@@ -112,7 +113,10 @@ const _parseTsconfig = (
 			compilerOptions.paths
 			&& !compilerOptions.baseUrl
 		) {
-			compilerOptions._implicitBaseUrl = directoryPath;
+			type WithImplicitBaseUrl = TsConfigJson.CompilerOptions & {
+				[implicitBaseUrlSymbol]: string;
+			};
+			(compilerOptions as WithImplicitBaseUrl)[implicitBaseUrlSymbol] = directoryPath;
 		}
 	}
 

--- a/src/parse-tsconfig/index.ts
+++ b/src/parse-tsconfig/index.ts
@@ -4,8 +4,8 @@ import type { TsConfigJson, TsConfigJsonResolved } from '../types.js';
 import { normalizePath } from '../utils/normalize-path.js';
 import { readJsonc } from '../utils/read-jsonc.js';
 import { realpath } from '../utils/fs-cached.js';
-import { resolveExtendsPath } from './resolve-extends-path.js';
 import { implicitBaseUrlSymbol } from '../utils/symbols.js';
+import { resolveExtendsPath } from './resolve-extends-path.js';
 
 const resolveExtends = (
 	extendsPath: string,

--- a/src/parse-tsconfig/index.ts
+++ b/src/parse-tsconfig/index.ts
@@ -34,20 +34,6 @@ const resolveExtends = (
 
 	const { compilerOptions } = extendsConfig;
 	if (compilerOptions) {
-		// const { baseUrl = '.', paths } = compilerOptions;
-		// if (paths) {
-		// 	for (const key in paths) {
-		// 		if (Array.isArray(paths[key])) {
-		// 			paths[key] = paths[key].map(
-		// 				p => normalizePath(path.relative(
-		// 					fromDirectoryPath,
-		// 					path.join(extendsDirectoryPath, baseUrl, p),
-		// 				)),
-		// 			);
-		// 		}
-		// 	}
-		// }
-
 		const resolvePaths = ['baseUrl', 'outDir'] as const;
 		for (const property of resolvePaths) {
 			const unresolvedPath = compilerOptions[property];
@@ -119,6 +105,17 @@ const _parseTsconfig = (
 	}
 
 	const directoryPath = path.dirname(realTsconfigPath);
+
+	if (config.compilerOptions) {
+		const { compilerOptions } = config;
+		if (
+			compilerOptions.paths
+			&& !compilerOptions.baseUrl
+		) {
+			compilerOptions._implicitBaseUrl = directoryPath;
+		}
+	}
+
 	if (config.extends) {
 		const extendsPathList = (
 			Array.isArray(config.extends)
@@ -157,7 +154,6 @@ const _parseTsconfig = (
 
 	if (config.compilerOptions) {
 		const { compilerOptions } = config;
-
 		const normalizedPaths = [
 			'baseUrl',
 			'rootDir',

--- a/src/parse-tsconfig/index.ts
+++ b/src/parse-tsconfig/index.ts
@@ -34,19 +34,19 @@ const resolveExtends = (
 
 	const { compilerOptions } = extendsConfig;
 	if (compilerOptions) {
-		const { baseUrl = '.', paths } = compilerOptions;
-		if (paths) {
-			for (const key in paths) {
-				if (Array.isArray(paths[key])) {
-					paths[key] = paths[key].map(
-						p => normalizePath(path.relative(
-							fromDirectoryPath,
-							path.join(extendsDirectoryPath, baseUrl, p),
-						)),
-					);
-				}
-			}
-		}
+		// const { baseUrl = '.', paths } = compilerOptions;
+		// if (paths) {
+		// 	for (const key in paths) {
+		// 		if (Array.isArray(paths[key])) {
+		// 			paths[key] = paths[key].map(
+		// 				p => normalizePath(path.relative(
+		// 					fromDirectoryPath,
+		// 					path.join(extendsDirectoryPath, baseUrl, p),
+		// 				)),
+		// 			);
+		// 		}
+		// 	}
+		// }
 
 		const resolvePaths = ['baseUrl', 'outDir'] as const;
 		for (const property of resolvePaths) {

--- a/src/paths-matcher/index.ts
+++ b/src/paths-matcher/index.ts
@@ -21,7 +21,7 @@ const parsePaths = (
 		substitutions: substitutions!.map((substitution) => {
 			assertStarCount(
 				substitution,
-					`Substitution '${substitution}' in pattern '${pattern}' can have at most one '*' character.`,
+				`Substitution '${substitution}' in pattern '${pattern}' can have at most one '*' character.`,
 			);
 
 			if (!baseUrl && !isRelativePathPattern.test(substitution)) {
@@ -44,14 +44,14 @@ export const createPathsMatcher = (
 		return null;
 	}
 
-	const { baseUrl, paths } = tsconfig.config.compilerOptions;
+	const { baseUrl, _implicitBaseUrl, paths } = tsconfig.config.compilerOptions;
 	if (!baseUrl && !paths) {
 		return null;
 	}
 
 	const resolvedBaseUrl = path.resolve(
 		path.dirname(tsconfig.path),
-		baseUrl || '.',
+		baseUrl || _implicitBaseUrl || '.',
 	);
 
 	const pathEntries = (

--- a/src/paths-matcher/index.ts
+++ b/src/paths-matcher/index.ts
@@ -2,13 +2,13 @@ import path from 'path';
 import slash from 'slash';
 import type { TsConfigResult } from '../types.js';
 import { isRelativePathPattern } from '../utils/is-relative-path-pattern.js';
+import { implicitBaseUrlSymbol } from '../utils/symbols.js';
 import {
 	assertStarCount,
 	parsePattern,
 	isPatternMatch,
 } from './utils.js';
 import type { StarPattern, PathEntry } from './types.js';
-import { implicitBaseUrlSymbol } from '../utils/symbols.js';
 
 const parsePaths = (
 	paths: Partial<Record<string, string[]>>,

--- a/src/paths-matcher/index.ts
+++ b/src/paths-matcher/index.ts
@@ -8,6 +8,7 @@ import {
 	isPatternMatch,
 } from './utils.js';
 import type { StarPattern, PathEntry } from './types.js';
+import { implicitBaseUrlSymbol } from '../utils/symbols.js';
 
 const parsePaths = (
 	paths: Partial<Record<string, string[]>>,
@@ -44,14 +45,18 @@ export const createPathsMatcher = (
 		return null;
 	}
 
-	const { baseUrl, _implicitBaseUrl, paths } = tsconfig.config.compilerOptions;
+	const { baseUrl, paths } = tsconfig.config.compilerOptions;
+	const implicitBaseUrl = (
+		implicitBaseUrlSymbol in tsconfig.config.compilerOptions
+		&& (tsconfig.config.compilerOptions[implicitBaseUrlSymbol] as string)
+	);
 	if (!baseUrl && !paths) {
 		return null;
 	}
 
 	const resolvedBaseUrl = path.resolve(
 		path.dirname(tsconfig.path),
-		baseUrl || _implicitBaseUrl || '.',
+		baseUrl || implicitBaseUrl || '.',
 	);
 
 	const pathEntries = (

--- a/src/utils/symbols.ts
+++ b/src/utils/symbols.ts
@@ -2,10 +2,10 @@
  * When a tsconfig extends another file with relative `paths` entries and the final tsconfig
  * doesn't have a `baseUrl` set, the relative paths are resolved relative to the tsconfig that
  * defined the `paths`
- * 
+ *
  * However, this is impossible to compute from a flattened tsconfig, because we no longer know
  * the path of the tsconfig that defined the `paths` entry.
- * 
+ *
  * This is why we store the implicit baseUrl in the flattened tsconfig, so that the pathsMatcher
  * can use it to resolve relative paths.
  */

--- a/src/utils/symbols.ts
+++ b/src/utils/symbols.ts
@@ -1,0 +1,12 @@
+/**
+ * When a tsconfig extends another file with relative `paths` entries and the final tsconfig
+ * doesn't have a `baseUrl` set, the relative paths are resolved relative to the tsconfig that
+ * defined the `paths`
+ * 
+ * However, this is impossible to compute from a flattened tsconfig, because we no longer know
+ * the path of the tsconfig that defined the `paths` entry.
+ * 
+ * This is why we store the implicit baseUrl in the flattened tsconfig, so that the pathsMatcher
+ * can use it to resolve relative paths.
+ */
+export const implicitBaseUrlSymbol = Symbol('implicitBaseUrl');

--- a/tests/specs/create-paths-matcher.ts
+++ b/tests/specs/create-paths-matcher.ts
@@ -524,21 +524,21 @@ export default testSuite(({ describe }) => {
 						extends: './tsconfigs/tsconfig.json',
 					}),
 				});
-	
+
 				const tsconfig = getTsconfig(fixture.path);
 				expect(tsconfig).not.toBeNull();
-	
+
 				const matcher = createPathsMatcher(tsconfig!)!;
 				expect(tsconfig).not.toBeNull();
-	
+
 				const resolvedAttempts = await getTscResolution('@', fixture.path);
 				expect(matcher('@')).toStrictEqual([
 					resolvedAttempts[0].filePath.slice(0, -3),
 				]);
-	
+
 				await fixture.rm();
 			});
-	
+
 			test('extended config should implicitly resolve paths from self', async () => {
 				const fixture = await createFixture({
 					tsconfigs: {
@@ -556,18 +556,18 @@ export default testSuite(({ describe }) => {
 						extends: './tsconfigs/tsconfig.json',
 					}),
 				});
-	
+
 				const tsconfig = getTsconfig(fixture.path);
 				expect(tsconfig).not.toBeNull();
-	
+
 				const matcher = createPathsMatcher(tsconfig!)!;
 				expect(tsconfig).not.toBeNull();
-	
+
 				const resolvedAttempts = await getTscResolution('@', fixture.path);
 				expect(matcher('@')).toStrictEqual([
 					resolvedAttempts[0].filePath.slice(0, -3),
 				]);
-	
+
 				await fixture.rm();
 			});
 
@@ -588,18 +588,18 @@ export default testSuite(({ describe }) => {
 						extends: './some-dir/tsconfig.json',
 					}),
 				});
-	
+
 				const tsconfig = getTsconfig(fixture.path);
 				expect(tsconfig).not.toBeNull();
-	
+
 				const matcher = createPathsMatcher(tsconfig!)!;
 				expect(tsconfig).not.toBeNull();
-	
+
 				const resolvedAttempts = await getTscResolution('@', fixture.path);
 				expect(matcher('@')).toStrictEqual([
 					resolvedAttempts[0].filePath.slice(0, -3),
 				]);
-	
+
 				await fixture.rm();
 			});
 		});

--- a/tests/specs/create-paths-matcher.ts
+++ b/tests/specs/create-paths-matcher.ts
@@ -506,100 +506,102 @@ export default testSuite(({ describe }) => {
 			await fixture.rm();
 		});
 
-		test('extended config should resolve relative to self', async () => {
-			const fixture = await createFixture({
-				tsconfigs: {
-					'tsconfig.json': createTsconfigJson({
-						compilerOptions: {
-							paths: {
-								'#imports': [
-									'./imports',
-								],
+		describe('extends w/ no baseUrl', ({ test }) => {
+			test('extended config should resolve relative to self', async () => {
+				const fixture = await createFixture({
+					tsconfigs: {
+						'tsconfig.json': createTsconfigJson({
+							compilerOptions: {
+								paths: {
+									'@': [
+										'./file',
+									],
+								},
 							},
-						},
-					}),
-				},
-				'tsconfig.json': createTsconfigJson({
-					extends: './tsconfigs/tsconfig.json',
-				}),
-			});
-
-			const tsconfig = getTsconfig(fixture.path);
-			expect(tsconfig).not.toBeNull();
-
-			const matcher = createPathsMatcher(tsconfig!)!;
-			expect(tsconfig).not.toBeNull();
-
-			const resolvedAttempts = await getTscResolution('#imports', fixture.path);
-			expect(matcher('#imports')).toStrictEqual([
-				resolvedAttempts[0].filePath.slice(0, -3),
-			]);
-
-			await fixture.rm();
-		});
-
-		test('extended config should implicitly resolve paths from self', async () => {
-			const fixture = await createFixture({
-				'file.ts': '',
-				'some-dir2/tsconfig.json': createTsconfigJson({
-					compilerOptions: {
-						paths: {
-							'@': ['./a'],
-						},
+						}),
 					},
-				}),
-				'some-dir/tsconfig.json': createTsconfigJson({
-					extends: '../some-dir2/tsconfig.json',
-				}),
-				'tsconfig.json': createTsconfigJson({
-					extends: './some-dir/tsconfig.json',
-				}),
+					'tsconfig.json': createTsconfigJson({
+						extends: './tsconfigs/tsconfig.json',
+					}),
+				});
+	
+				const tsconfig = getTsconfig(fixture.path);
+				expect(tsconfig).not.toBeNull();
+	
+				const matcher = createPathsMatcher(tsconfig!)!;
+				expect(tsconfig).not.toBeNull();
+	
+				const resolvedAttempts = await getTscResolution('@', fixture.path);
+				expect(matcher('@')).toStrictEqual([
+					resolvedAttempts[0].filePath.slice(0, -3),
+				]);
+	
+				await fixture.rm();
+			});
+	
+			test('extended config should implicitly resolve paths from self', async () => {
+				const fixture = await createFixture({
+					tsconfigs: {
+						'tsconfig.json': createTsconfigJson({
+							compilerOptions: {
+								paths: {
+									'@': [
+										'./file',
+									],
+								},
+							},
+						}),
+					},
+					'tsconfig.json': createTsconfigJson({
+						extends: './tsconfigs/tsconfig.json',
+					}),
+				});
+	
+				const tsconfig = getTsconfig(fixture.path);
+				expect(tsconfig).not.toBeNull();
+	
+				const matcher = createPathsMatcher(tsconfig!)!;
+				expect(tsconfig).not.toBeNull();
+	
+				const resolvedAttempts = await getTscResolution('@', fixture.path);
+				expect(matcher('@')).toStrictEqual([
+					resolvedAttempts[0].filePath.slice(0, -3),
+				]);
+	
+				await fixture.rm();
 			});
 
-			const tsconfig = getTsconfig(fixture.path);
-			expect(tsconfig).not.toBeNull();
-
-			const matcher = createPathsMatcher(tsconfig!)!;
-			expect(tsconfig).not.toBeNull();
-
-			const resolvedAttempts = await getTscResolution('@', fixture.path);
-			expect(matcher('@')).toStrictEqual([
-				resolvedAttempts[0].filePath.slice(0, -3),
-			]);
-
-			await fixture.rm();
-		});
-
-		test('extended config should resolve relative to self 2', async () => {
-			const fixture = await createFixture({
-				tsconfigs: {
-					'tsconfig.json': createTsconfigJson({
+			test('extended config should implicitly resolve paths from self - complex', async () => {
+				const fixture = await createFixture({
+					'file.ts': '',
+					'some-dir2/tsconfig.json': createTsconfigJson({
 						compilerOptions: {
 							paths: {
-								'#imports': [
-									'./imports',
-								],
+								'@': ['./a'],
 							},
 						},
 					}),
-				},
-				'tsconfig.json': createTsconfigJson({
-					extends: './tsconfigs/tsconfig.json',
-				}),
+					'some-dir/tsconfig.json': createTsconfigJson({
+						extends: '../some-dir2/tsconfig.json',
+					}),
+					'tsconfig.json': createTsconfigJson({
+						extends: './some-dir/tsconfig.json',
+					}),
+				});
+	
+				const tsconfig = getTsconfig(fixture.path);
+				expect(tsconfig).not.toBeNull();
+	
+				const matcher = createPathsMatcher(tsconfig!)!;
+				expect(tsconfig).not.toBeNull();
+	
+				const resolvedAttempts = await getTscResolution('@', fixture.path);
+				expect(matcher('@')).toStrictEqual([
+					resolvedAttempts[0].filePath.slice(0, -3),
+				]);
+	
+				await fixture.rm();
 			});
-
-			const tsconfig = getTsconfig(fixture.path);
-			expect(tsconfig).not.toBeNull();
-
-			const matcher = createPathsMatcher(tsconfig!)!;
-			expect(tsconfig).not.toBeNull();
-
-			const resolvedAttempts = await getTscResolution('#imports', fixture.path);
-			expect(matcher('#imports')).toStrictEqual([
-				resolvedAttempts[0].filePath.slice(0, -3),
-			]);
-
-			await fixture.rm();
 		});
 	});
 });

--- a/tests/specs/create-paths-matcher.ts
+++ b/tests/specs/create-paths-matcher.ts
@@ -506,36 +506,100 @@ export default testSuite(({ describe }) => {
 			await fixture.rm();
 		});
 
-		// test('extended config should resolve relative to self', async () => {
-		// 	const fixture = await createFixture({
-		// 		tsconfigs: {
-		// 			'tsconfig.json': createTsconfigJson({
-		// 				compilerOptions: {
-		// 					paths: {
-		// 						'#imports': [
-		// 							'./imports',
-		// 						],
-		// 					},
-		// 				},
-		// 			}),
-		// 		},
-		// 		'tsconfig.json': createTsconfigJson({
-		// 			extends: './tsconfigs/tsconfig.json',
-		// 		}),
-		// 	});
+		test('extended config should resolve relative to self', async () => {
+			const fixture = await createFixture({
+				tsconfigs: {
+					'tsconfig.json': createTsconfigJson({
+						compilerOptions: {
+							paths: {
+								'#imports': [
+									'./imports',
+								],
+							},
+						},
+					}),
+				},
+				'tsconfig.json': createTsconfigJson({
+					extends: './tsconfigs/tsconfig.json',
+				}),
+			});
 
-		// 	const tsconfig = getTsconfig(fixture.path);
-		// 	expect(tsconfig).not.toBeNull();
+			const tsconfig = getTsconfig(fixture.path);
+			expect(tsconfig).not.toBeNull();
 
-		// 	const matcher = createPathsMatcher(tsconfig!)!;
-		// 	expect(tsconfig).not.toBeNull();
+			const matcher = createPathsMatcher(tsconfig!)!;
+			expect(tsconfig).not.toBeNull();
 
-		// 	const resolvedAttempts = await getTscResolution('#imports', fixture.path);
-		// 	expect(matcher('#imports')).toStrictEqual([
-		// 		resolvedAttempts[0].filePath.slice(0, -3),
-		// 	]);
+			const resolvedAttempts = await getTscResolution('#imports', fixture.path);
+			expect(matcher('#imports')).toStrictEqual([
+				resolvedAttempts[0].filePath.slice(0, -3),
+			]);
 
-		// 	await fixture.rm();
-		// });
+			await fixture.rm();
+		});
+
+		test('extended config should implicitly resolve paths from self', async () => {
+			const fixture = await createFixture({
+				'file.ts': '',
+				'some-dir2/tsconfig.json': createTsconfigJson({
+					compilerOptions: {
+						paths: {
+							'@': ['./a'],
+						},
+					},
+				}),
+				'some-dir/tsconfig.json': createTsconfigJson({
+					extends: '../some-dir2/tsconfig.json',
+				}),
+				'tsconfig.json': createTsconfigJson({
+					extends: './some-dir/tsconfig.json',
+				}),
+			});
+
+			const tsconfig = getTsconfig(fixture.path);
+			expect(tsconfig).not.toBeNull();
+
+			const matcher = createPathsMatcher(tsconfig!)!;
+			expect(tsconfig).not.toBeNull();
+
+			const resolvedAttempts = await getTscResolution('@', fixture.path);
+			expect(matcher('@')).toStrictEqual([
+				resolvedAttempts[0].filePath.slice(0, -3),
+			]);
+
+			await fixture.rm();
+		});
+
+		test('extended config should resolve relative to self 2', async () => {
+			const fixture = await createFixture({
+				tsconfigs: {
+					'tsconfig.json': createTsconfigJson({
+						compilerOptions: {
+							paths: {
+								'#imports': [
+									'./imports',
+								],
+							},
+						},
+					}),
+				},
+				'tsconfig.json': createTsconfigJson({
+					extends: './tsconfigs/tsconfig.json',
+				}),
+			});
+
+			const tsconfig = getTsconfig(fixture.path);
+			expect(tsconfig).not.toBeNull();
+
+			const matcher = createPathsMatcher(tsconfig!)!;
+			expect(tsconfig).not.toBeNull();
+
+			const resolvedAttempts = await getTscResolution('#imports', fixture.path);
+			expect(matcher('#imports')).toStrictEqual([
+				resolvedAttempts[0].filePath.slice(0, -3),
+			]);
+
+			await fixture.rm();
+		});
 	});
 });

--- a/tests/specs/create-paths-matcher.ts
+++ b/tests/specs/create-paths-matcher.ts
@@ -12,7 +12,7 @@ import { getTsconfig, createPathsMatcher } from '#get-tsconfig';
 export default testSuite(({ describe }) => {
 	describe('paths', ({ describe, test }) => {
 		describe('error cases', ({ test }) => {
-			test('no baseUrl or paths', async () => {
+			test('no baseUrl or paths should be fine', async () => {
 				const fixture = await createFixture({
 					'tsconfig.json': createTsconfigJson({
 						compilerOptions: {},
@@ -26,7 +26,7 @@ export default testSuite(({ describe }) => {
 				await fixture.rm();
 			});
 
-			test('no baseUrl & non-relative paths', async () => {
+			test('no baseUrl nor relative paths', async () => {
 				const fixture = await createFixture({
 					'tsconfig.json': createTsconfigJson({
 						compilerOptions: {
@@ -34,6 +34,40 @@ export default testSuite(({ describe }) => {
 								'@': ['src'],
 							},
 						},
+					}),
+				});
+
+				let throwsError = false;
+				const errorMessage = 'Non-relative paths are not allowed when \'baseUrl\' is not set. Did you forget a leading \'./\'?';
+				try {
+					await getTscResolution('@', fixture.path);
+				} catch (error) {
+					throwsError = true;
+					expect((error as any).stdout).toMatch(errorMessage);
+				}
+				expect(throwsError).toBe(true);
+
+				const tsconfig = getTsconfig(fixture.path);
+				expect(tsconfig).not.toBeNull();
+				expect(() => createPathsMatcher(tsconfig!)).toThrow(errorMessage);
+
+				await fixture.rm();
+			});
+
+			test('no baseUrl nor relative paths in extends', async () => {
+				const fixture = await createFixture({
+					'some-dir2/tsconfig.json': createTsconfigJson({
+						compilerOptions: {
+							paths: {
+								'@': ['src'],
+							},
+						},
+					}),
+					'some-dir/tsconfig.json': createTsconfigJson({
+						extends: '../some-dir2/tsconfig.json',
+					}),
+					'tsconfig.json': createTsconfigJson({
+						extends: './some-dir/tsconfig.json',
 					}),
 				});
 
@@ -472,36 +506,36 @@ export default testSuite(({ describe }) => {
 			await fixture.rm();
 		});
 
-		test('extended config should resolve relative to self', async () => {
-			const fixture = await createFixture({
-				tsconfigs: {
-					'tsconfig.json': createTsconfigJson({
-						compilerOptions: {
-							paths: {
-								'#imports': [
-									'./imports',
-								],
-							},
-						},
-					}),
-				},
-				'tsconfig.json': createTsconfigJson({
-					extends: './tsconfigs/tsconfig.json',
-				}),
-			});
+		// test('extended config should resolve relative to self', async () => {
+		// 	const fixture = await createFixture({
+		// 		tsconfigs: {
+		// 			'tsconfig.json': createTsconfigJson({
+		// 				compilerOptions: {
+		// 					paths: {
+		// 						'#imports': [
+		// 							'./imports',
+		// 						],
+		// 					},
+		// 				},
+		// 			}),
+		// 		},
+		// 		'tsconfig.json': createTsconfigJson({
+		// 			extends: './tsconfigs/tsconfig.json',
+		// 		}),
+		// 	});
 
-			const tsconfig = getTsconfig(fixture.path);
-			expect(tsconfig).not.toBeNull();
+		// 	const tsconfig = getTsconfig(fixture.path);
+		// 	expect(tsconfig).not.toBeNull();
 
-			const matcher = createPathsMatcher(tsconfig!)!;
-			expect(tsconfig).not.toBeNull();
+		// 	const matcher = createPathsMatcher(tsconfig!)!;
+		// 	expect(tsconfig).not.toBeNull();
 
-			const resolvedAttempts = await getTscResolution('#imports', fixture.path);
-			expect(matcher('#imports')).toStrictEqual([
-				resolvedAttempts[0].filePath.slice(0, -3),
-			]);
+		// 	const resolvedAttempts = await getTscResolution('#imports', fixture.path);
+		// 	expect(matcher('#imports')).toStrictEqual([
+		// 		resolvedAttempts[0].filePath.slice(0, -3),
+		// 	]);
 
-			await fixture.rm();
-		});
+		// 	await fixture.rm();
+		// });
 	});
 });

--- a/tests/specs/parse-tsconfig/extends/merges.spec.ts
+++ b/tests/specs/parse-tsconfig/extends/merges.spec.ts
@@ -312,6 +312,31 @@ export default testSuite(({ describe }) => {
 
 				await fixture.rm();
 			});
+
+			test('resolves parent baseUrl & paths', async () => {
+				const fixture = await createFixture({
+					'project/tsconfig.json': createTsconfigJson({
+						compilerOptions: {
+							baseUrl: '.',
+							paths: {
+								'@/*': ['src/*'],
+							},
+						},
+					}),
+					'tsconfig.json': createTsconfigJson({
+						extends: './project/tsconfig.json',
+					}),
+					'a.ts': '',
+				});
+
+				const expectedTsconfig = await getTscTsconfig(fixture.path);
+				delete expectedTsconfig.files;
+
+				const tsconfig = parseTsconfig(path.join(fixture.path, 'tsconfig.json'));
+				expect(tsconfig).toStrictEqual(expectedTsconfig);
+
+				await fixture.rm();
+			});
 		});
 
 		test('nested extends', async () => {


### PR DESCRIPTION
fix https://github.com/privatenumber/get-tsconfig/issues/61

When a tsconfig file extends another one that defines `paths` and the resolved `tsconfig` doesn't contain a `baseUrl`, the `paths` are resolved relative to the path of the tsconfig file that defined it.

However, in a resolved tsconfig file, we don't know the tsconfig paths that were considered. So it's impossible to know that the `paths` need to be resolved from a different path.

I could solve this by pre-resolving the `paths` each time they're extended, but this creates a discrepancy between TypeScript's "showConfig" feature vs get-tsconfig's. So instead, I decided to store the path of the tsconfig that defined the `paths` in a symbol so it can be used by the paths resolver.

In the future, it might make more sense for both get-tsconfig and TypeScript to show the resolved paths in the "showConfig" feature as it's impossible to use that data to correctly resolve paths.