### PR TITLE
fix: resolve relative path extends in parent directory

### DIFF
--- a/src/parse-tsconfig/resolve-extends-path.ts
+++ b/src/parse-tsconfig/resolve-extends-path.ts
@@ -144,7 +144,7 @@ export const resolveExtendsPath = (
 	}
 
 	const packagePath = findUp(
-		directoryPath,
+		path.resolve(directoryPath),
 		path.join('node_modules', packageName),
 		cache,
 	);

--- a/tests/specs/parse-tsconfig/extends/merges.spec.ts
+++ b/tests/specs/parse-tsconfig/extends/merges.spec.ts
@@ -258,15 +258,15 @@ export default testSuite(({ describe }) => {
 			// https://github.com/privatenumber/get-tsconfig/issues/76
 			test('supports config files in a monorepo', async () => {
 				await using fixture = await createFixture({
-					'packages': {
-						'tsconfig': {
+					packages: {
+						tsconfig: {
 							'tsconfig.base.json': createTsconfigJson({
 								compilerOptions: {
 									module: 'commonjs',
 								},
 							}),
 						},
-						'library': {
+						library: {
 							src: {
 								'a.ts': '',
 								'b.ts': '',

--- a/tests/specs/parse-tsconfig/extends/merges.spec.ts
+++ b/tests/specs/parse-tsconfig/extends/merges.spec.ts
@@ -281,7 +281,11 @@ export default testSuite(({ describe }) => {
 				});
 
 				await fs.mkdir(path.join(fixture.path, 'node_modules', '@monorepo'), { recursive: true });
-				await fs.symlink(fixture.getPath('packages/tsconfig'), fixture.getPath('node_modules/@monorepo/tsconfig'));
+				await fs.symlink(
+					fixture.getPath('packages/tsconfig'),
+					fixture.getPath('node_modules/@monorepo/tsconfig'),
+					'junction',
+				);
 
 				const originalCwd = process.cwd();
 				try {

--- a/tests/specs/parse-tsconfig/extends/merges.spec.ts
+++ b/tests/specs/parse-tsconfig/extends/merges.spec.ts
@@ -254,52 +254,6 @@ export default testSuite(({ describe }) => {
 					include: tsconfig.include?.map(includePath => `symlink/../${includePath}`),
 				}).toStrictEqual(expectedTsconfig);
 			});
-
-			// https://github.com/privatenumber/get-tsconfig/issues/76
-			test('supports config files in a monorepo', async () => {
-				await using fixture = await createFixture({
-					packages: {
-						tsconfig: {
-							'tsconfig.base.json': createTsconfigJson({
-								compilerOptions: {
-									module: 'commonjs',
-								},
-							}),
-						},
-						library: {
-							src: {
-								'a.ts': '',
-								'b.ts': '',
-								'c.ts': '',
-							},
-							'tsconfig.json': createTsconfigJson({
-								extends: '@monorepo/tsconfig/tsconfig.base.json',
-								include: ['src'],
-							}),
-						},
-					},
-				});
-
-				await fs.mkdir(path.join(fixture.path, 'node_modules', '@monorepo'), { recursive: true });
-				await fs.symlink(
-					fixture.getPath('packages/tsconfig'),
-					fixture.getPath('node_modules/@monorepo/tsconfig'),
-					'junction',
-				);
-
-				const originalCwd = process.cwd();
-				try {
-					process.chdir(fixture.getPath('packages/library'));
-					const expectedTsconfig = await getTscTsconfig('.');
-					delete expectedTsconfig.files;
-
-					const tsconfig = parseTsconfig('./tsconfig.json');
-
-					expect(tsconfig).toStrictEqual(expectedTsconfig);
-				} finally {
-					process.chdir(originalCwd);
-				}
-			});
 		});
 
 		describe('baseUrl', ({ test }) => {


### PR DESCRIPTION
Closes https://github.com/privatenumber/get-tsconfig/issues/76.

Using `path.resolve` to obtain an absolute path ensures that we search all the way up, instead of stopping at `directoryPath`.