### PR TITLE
fix: support `configDir` for other `compilerOptions` fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 
+# JetBrains (WebStorm)
+.idea
+
 # Dependency directories
 node_modules/
 

--- a/src/parse-tsconfig/index.ts
+++ b/src/parse-tsconfig/index.ts
@@ -37,7 +37,7 @@ const resolveExtends = (
 	const { compilerOptions } = extendsConfig;
 	if (compilerOptions) {
 		const { baseUrl } = compilerOptions;
-		if (baseUrl != null && !baseUrl.startsWith(configDirPlaceholder)) {
+		if (baseUrl && !baseUrl.startsWith(configDirPlaceholder)) {
 			compilerOptions.baseUrl = slash(
 				path.relative(
 					fromDirectoryPath,
@@ -166,7 +166,7 @@ const _parseTsconfig = (
 
 		for (const property of normalizedPaths) {
 			const unresolvedPath = compilerOptions[property];
-			if (unresolvedPath != null && !unresolvedPath.startsWith(configDirPlaceholder)) {
+			if (unresolvedPath && !unresolvedPath.startsWith(configDirPlaceholder)) {
 				const resolvedBaseUrl = path.resolve(directoryPath, unresolvedPath);
 				const relativeBaseUrl = normalizeRelativePath(path.relative(
 					directoryPath,
@@ -222,18 +222,19 @@ const _parseTsconfig = (
 	return config;
 };
 
-function interpolateConfigDir<T extends string | string[]> (
+function interpolateConfigDir<T extends string | string[]>(
 	filePaths: T,
 	configDir: string,
 	postProcess?: (input: string) => string
 ): T extends string ? string : string[];
-function interpolateConfigDir (
+// eslint-disable-next-line pvtnbr/prefer-arrow-functions
+function interpolateConfigDir(
 	filePaths: string | string[],
 	configDir: string,
-	postProcess: (input: string) => string = (value) => value
+	postProcess: (input: string) => string = value => value,
 ): string | string[] {
 	if (Array.isArray(filePaths)) {
-		return filePaths.map((filePath) => interpolateConfigDir(filePath, configDir, postProcess));
+		return filePaths.map(filePath => interpolateConfigDir(filePath, configDir, postProcess));
 	}
 
 	if (filePaths.startsWith(configDirPlaceholder)) {
@@ -270,13 +271,18 @@ export const parseTsconfig = (
 		for (const field of compilerFieldsWithConfigDir) {
 			const value = config.compilerOptions[field];
 
-			if (value != null) {
+			if (value) {
 				/**
-				 * I used Object.assign instead of the direct assignment to work around TS bug (it fails to infer types correctly).
+				 * I used Object.assign instead of the direct assignment to work around TS bug
+				 * (it fails to infer types correctly).
 				 * @see https://github.com/microsoft/TypeScript/issues/33912
  				 */
 				Object.assign(config.compilerOptions, {
-					[field]: interpolateConfigDir(value, configDir, (interpolated) => normalizeRelativePath(path.relative(configDir, interpolated)))
+					[field]: interpolateConfigDir(
+						value,
+						configDir,
+						interpolated => normalizeRelativePath(path.relative(configDir, interpolated)),
+					),
 				});
 			}
 		}

--- a/src/parse-tsconfig/index.ts
+++ b/src/parse-tsconfig/index.ts
@@ -178,7 +178,7 @@ const _parseTsconfig = (
 
 		const outputFields = [
 			'outDir',
-			'declarationDir'
+			'declarationDir',
 		] as const satisfies Array<keyof NonNullable<TsConfigJson['compilerOptions']>>;
 
 		for (const outputField of outputFields) {

--- a/src/parse-tsconfig/index.ts
+++ b/src/parse-tsconfig/index.ts
@@ -176,20 +176,29 @@ const _parseTsconfig = (
 			}
 		}
 
-		let { outDir } = compilerOptions;
-		if (outDir) {
-			if (!Array.isArray(config.exclude)) {
-				config.exclude = [];
-			}
+		const outputFields = [
+			'outDir',
+			'declarationDir'
+		] as const satisfies Array<keyof NonNullable<TsConfigJson['compilerOptions']>>;
 
-			if (!config.exclude.includes(outDir)) {
-				config.exclude.push(outDir);
-			}
+		for (const outputField of outputFields) {
+			let outputPath = compilerOptions[outputField];
 
-			if (!outDir.startsWith(configDirPlaceholder)) {
-				outDir = normalizeRelativePath(outDir);
+			if (outputPath) {
+				if (!Array.isArray(config.exclude)) {
+					config.exclude = [];
+				}
+
+				if (!config.exclude.includes(outputPath)) {
+					config.exclude.push(outputPath);
+				}
+
+				if (!outputPath.startsWith(configDirPlaceholder)) {
+					outputPath = normalizeRelativePath(outputPath);
+				}
+
+				compilerOptions[outputField] = outputPath;
 			}
-			compilerOptions.outDir = outDir;
 		}
 	} else {
 		config.compilerOptions = {};

--- a/tests/specs/parse-tsconfig/extends/merges.spec.ts
+++ b/tests/specs/parse-tsconfig/extends/merges.spec.ts
@@ -492,6 +492,13 @@ export default testSuite(({ describe }) => {
 					'tsconfig.json': createTsconfigJson({
 						compilerOptions: {
 							outDir: '${configDir}-asdf/dist',
+							declarationDir: '${configDir}/dist/declaration',
+							outFile: '${configDir}/dist/outfile.js',
+							rootDir: '${configDir}/dist/src',
+							baseUrl: '${configDir}/dist/src',
+							tsBuildInfoFile: '${configDir}/dist/dist.tsbuildinfo',
+							rootDirs: ['${configDir}/src', '${configDir}/static'],
+							typeRoots: ['${configDir}/src/type', '${configDir}/types'],
 							paths: {
 								a: ['${configDir}_a/*'],
 								b: ['ignores/${configDir}/*'],

--- a/tests/specs/parse-tsconfig/parses.spec.ts
+++ b/tests/specs/parse-tsconfig/parses.spec.ts
@@ -73,6 +73,7 @@ export default testSuite(({ describe }) => {
 						esModuleInterop: true,
 						declaration: true,
 						outDir: 'dist',
+						declarationDir: 'dist-declaration',
 						strict: true,
 						target: 'esnext',
 						rootDir: 'root-dir',


### PR DESCRIPTION
This PR adds support for the "${configDir}" variable interpolation for all the fields in "compilerOptions" object as listed in the [original issue](https://github.com/microsoft/TypeScript/issues/57485#issuecomment-2027787456)