### PR TITLE
fix: default `moduleResolution` for `module: preserve`

### DIFF
--- a/src/parse-tsconfig/index.ts
+++ b/src/parse-tsconfig/index.ts
@@ -291,7 +291,6 @@ const normalizeCompilerOptions = (
 
 		if (target === 'esnext') {
 			compilerOptions.module ??= 'es6';
-			compilerOptions.moduleResolution ??= 'classic';
 			compilerOptions.useDefineForClassFields ??= true;
 		}
 
@@ -308,7 +307,6 @@ const normalizeCompilerOptions = (
 			|| target === 'es2024'
 		) {
 			compilerOptions.module ??= 'es6';
-			compilerOptions.moduleResolution ??= 'classic';
 		}
 
 		if (

--- a/tests/specs/parse-tsconfig/parses.spec.ts
+++ b/tests/specs/parse-tsconfig/parses.spec.ts
@@ -93,6 +93,24 @@ export default testSuite(({ describe }) => {
 			expect(expectedTsconfig).toStrictEqual(parsedTsconfig);
 		});
 
+		test('implicit config', async () => {
+			await using fixture = await createFixture({
+				'file.ts': '',
+				'tsconfig.json': createTsconfigJson({
+					compilerOptions: {
+						target: 'es2022',
+						module: 'preserve',
+					},
+				}),
+			});
+
+			const parsedTsconfig = parseTsconfig(fixture.getPath('tsconfig.json'));
+			const expectedTsconfig = await getTscTsconfig(fixture.path);
+			delete expectedTsconfig.files;
+
+			expect(expectedTsconfig).toStrictEqual(parsedTsconfig);
+		});
+
 		describe('baseUrl', ({ test }) => {
 			test('relative path', async () => {
 				await using fixture = await createFixture({


### PR DESCRIPTION
- When `target` is set to `es2022` and `module` is `preserve`, the default value of `moduleResolution` should be `bundler`.
- In fact, the default value of `moduleResolution` depends only on the `module` setting, not on `target`.

Downstream https://github.com/rolldown/tsdown/issues/235