### PR TITLE
fix(parse-tsconfig): preserve files when include is also present

### DIFF
--- a/src/parse-tsconfig/index.ts
+++ b/src/parse-tsconfig/index.ts
@@ -233,11 +233,9 @@ const _parseTsconfig = (
 
 	if (config.include) {
 		config.include = config.include.map(slash);
+	}
 
-		if (config.files) {
-			delete config.files;
-		}
-	} else if (config.files) {
+	if (config.files) {
 		config.files = config.files.map(file => (
 			file.startsWith(configDirPlaceholder)
 				? file

--- a/tests/specs/parse-tsconfig/extends/merges.spec.ts
+++ b/tests/specs/parse-tsconfig/extends/merges.spec.ts
@@ -140,7 +140,7 @@ export default testSuite(({ describe }) => {
 				expect(tsconfig).toStrictEqual(expectedTsconfig);
 			});
 
-			test('preserved with include', async () => {
+			test('preserved when child has include', async () => {
 				await using fixture = await createFixture({
 					src: {
 						'a.ts': '',
@@ -159,13 +159,58 @@ export default testSuite(({ describe }) => {
 					}),
 				});
 
+				const expectedTsconfig = await getTscTsconfig(fixture.path);
+				// tsc expands include globs into the files array, so compare
+				// include/files/compilerOptions independently
 				const tsconfig = parseTsconfig(fixture.getPath('tsconfig.json'));
+				expect(tsconfig.include).toStrictEqual(expectedTsconfig.include);
+				expect(tsconfig.files).toStrictEqual(['./types/globals.d.ts']);
+				expect(tsconfig.compilerOptions).toStrictEqual(expectedTsconfig.compilerOptions);
+			});
 
-				expect(tsconfig).toStrictEqual({
-					compilerOptions: {},
-					files: ['./types/globals.d.ts'],
-					include: ['src'],
+			test('preserved when child has files and parent has include', async () => {
+				await using fixture = await createFixture({
+					src: {
+						'a.ts': '',
+					},
+					'globals.d.ts': '',
+					'tsconfig.base.json': createTsconfigJson({
+						include: ['src'],
+					}),
+					'tsconfig.json': createTsconfigJson({
+						extends: './tsconfig.base.json',
+						files: ['globals.d.ts'],
+					}),
 				});
+
+				const expectedTsconfig = await getTscTsconfig(fixture.path);
+				const tsconfig = parseTsconfig(fixture.getPath('tsconfig.json'));
+				expect(tsconfig.include).toStrictEqual(expectedTsconfig.include);
+				expect(tsconfig.files).toStrictEqual(['./globals.d.ts']);
+			});
+
+			test('both inherited from parent', async () => {
+				await using fixture = await createFixture({
+					src: {
+						'a.ts': '',
+					},
+					types: {
+						'globals.d.ts': '',
+					},
+					'tsconfig.base.json': createTsconfigJson({
+						files: ['types/globals.d.ts'],
+						include: ['src'],
+					}),
+					'tsconfig.json': createTsconfigJson({
+						extends: './tsconfig.base.json',
+					}),
+				});
+
+				const expectedTsconfig = await getTscTsconfig(fixture.path);
+				const tsconfig = parseTsconfig(fixture.getPath('tsconfig.json'));
+				expect(tsconfig.include).toStrictEqual(expectedTsconfig.include);
+				// tsc expands include globs into files; get-tsconfig keeps them separate
+				expect(tsconfig.files).toStrictEqual(['./types/globals.d.ts']);
 			});
 
 			test('gets overwritten', async () => {

--- a/tests/specs/parse-tsconfig/extends/merges.spec.ts
+++ b/tests/specs/parse-tsconfig/extends/merges.spec.ts
@@ -140,6 +140,34 @@ export default testSuite(({ describe }) => {
 				expect(tsconfig).toStrictEqual(expectedTsconfig);
 			});
 
+			test('preserved with include', async () => {
+				await using fixture = await createFixture({
+					src: {
+						'a.ts': '',
+					},
+					types: {
+						'globals.d.ts': '',
+					},
+					'tsconfig.base.json': createTsconfigJson({
+						files: [
+							'types/globals.d.ts',
+						],
+					}),
+					'tsconfig.json': createTsconfigJson({
+						extends: './tsconfig.base.json',
+						include: ['src'],
+					}),
+				});
+
+				const tsconfig = parseTsconfig(fixture.getPath('tsconfig.json'));
+
+				expect(tsconfig).toStrictEqual({
+					compilerOptions: {},
+					files: ['./types/globals.d.ts'],
+					include: ['src'],
+				});
+			});
+
 			test('gets overwritten', async () => {
 				await using fixture = await createFixture({
 					'some-dir': {


### PR DESCRIPTION
When a tsconfig extends a base config that defines `files`, and the child config defines `include`, the inherited `files` array was deleted (`delete config.files`). TypeScript itself preserves both properties — `files` entries are always included regardless of `include`/`exclude`.

**Before:** `files` from extended config silently dropped when child has `include`
**After:** `files` paths are normalized instead of deleted, matching TypeScript behavior

### Scenario

```json
// tsconfig.base.json
{ "files": ["types/globals.d.ts"] }

// tsconfig.json
{ "extends": "./tsconfig.base.json", "include": ["src"] }
```

`get-tsconfig` returned `{ include: ["src"] }` — `files` was lost.
TypeScript resolves both: the `files` entries *and* the `include` glob.

### Verified against TypeScript source

`commandLineParser.ts` lines 3463–3473: `files`, `include`, and `exclude` are independently inheritable via `setPropertyInResultIfNotUndefined`. Line 3143: the default `include: ["**/*"]` only applies when both `files` and `include` are absent.