### PR TITLE
fix(parse-tsconfig): rewrite inherited path fields in extends

### DIFF
--- a/src/parse-tsconfig/index.ts
+++ b/src/parse-tsconfig/index.ts
@@ -115,20 +115,16 @@ const resolveExtends = (
 
 		const { rootDirs } = compilerOptions;
 		if (rootDirs) {
-			compilerOptions.rootDirs = rootDirs.map(dir =>
-				dir.startsWith(configDirPlaceholder)
-					? dir
-					: resolveAndRelativize(fromDirectoryPath, extendsDirectoryPath, dir),
-			);
+			compilerOptions.rootDirs = rootDirs.map(dir => (dir.startsWith(configDirPlaceholder)
+				? dir
+				: resolveAndRelativize(fromDirectoryPath, extendsDirectoryPath, dir)));
 		}
 
 		const { typeRoots } = compilerOptions;
 		if (typeRoots) {
-			compilerOptions.typeRoots = typeRoots.map(root =>
-				root.startsWith(configDirPlaceholder)
-					? root
-					: resolveAndRelativize(fromDirectoryPath, extendsDirectoryPath, root),
-			);
+			compilerOptions.typeRoots = typeRoots.map(root => (root.startsWith(configDirPlaceholder)
+				? root
+				: resolveAndRelativize(fromDirectoryPath, extendsDirectoryPath, root)));
 		}
 	}
 

--- a/src/parse-tsconfig/index.ts
+++ b/src/parse-tsconfig/index.ts
@@ -94,6 +94,42 @@ const resolveExtends = (
 				outDir,
 			);
 		}
+
+		const { declarationDir } = compilerOptions;
+		if (declarationDir && !declarationDir.startsWith(configDirPlaceholder)) {
+			compilerOptions.declarationDir = resolveAndRelativize(
+				fromDirectoryPath,
+				extendsDirectoryPath,
+				declarationDir,
+			);
+		}
+
+		const { rootDir } = compilerOptions;
+		if (rootDir && !rootDir.startsWith(configDirPlaceholder)) {
+			compilerOptions.rootDir = resolveAndRelativize(
+				fromDirectoryPath,
+				extendsDirectoryPath,
+				rootDir,
+			);
+		}
+
+		const { rootDirs } = compilerOptions;
+		if (rootDirs) {
+			compilerOptions.rootDirs = rootDirs.map(dir =>
+				dir.startsWith(configDirPlaceholder)
+					? dir
+					: resolveAndRelativize(fromDirectoryPath, extendsDirectoryPath, dir),
+			);
+		}
+
+		const { typeRoots } = compilerOptions;
+		if (typeRoots) {
+			compilerOptions.typeRoots = typeRoots.map(root =>
+				root.startsWith(configDirPlaceholder)
+					? root
+					: resolveAndRelativize(fromDirectoryPath, extendsDirectoryPath, root),
+			);
+		}
 	}
 
 	for (const property of filesProperties) {
@@ -561,7 +597,9 @@ export const parseTsconfig = (
 			if (value) {
 				compilerOptions[property] = value.map((v) => {
 					const resolvedPath = interpolateConfigDir(v, configDir);
-					return resolvedPath ? pathRelative(configDir, resolvedPath) : v;
+					return resolvedPath
+						? pathRelative(configDir, resolvedPath)
+						: normalizeRelativePath(v);
 				});
 			}
 		}

--- a/tests/specs/parse-tsconfig/extends/merges.spec.ts
+++ b/tests/specs/parse-tsconfig/extends/merges.spec.ts
@@ -483,6 +483,180 @@ export default testSuite(({ describe }) => {
 			});
 		});
 
+		describe('rootDir', ({ test }) => {
+			test('gets inherited with relative path', async () => {
+				await using fixture = await createFixture({
+					project: {
+						src: {
+							'a.ts': '',
+						},
+						'tsconfig.json': createTsconfigJson({
+							compilerOptions: {
+								rootDir: 'src',
+							},
+						}),
+					},
+					'tsconfig.json': createTsconfigJson({
+						extends: './project/tsconfig.json',
+					}),
+					'file.ts': '',
+				});
+
+				const expectedTsconfig = await getTscTsconfig(fixture.path);
+				delete expectedTsconfig.files;
+
+				const tsconfig = parseTsconfig(fixture.getPath('tsconfig.json'));
+				expect(tsconfig).toStrictEqual(expectedTsconfig);
+			});
+
+			test('resolves parent rootDir path', async () => {
+				await using fixture = await createFixture({
+					'project/tsconfig.json': createTsconfigJson({
+						compilerOptions: {
+							rootDir: '..',
+						},
+					}),
+					'tsconfig.json': createTsconfigJson({
+						extends: './project/tsconfig.json',
+					}),
+					'a.ts': '',
+				});
+
+				const expectedTsconfig = await getTscTsconfig(fixture.path);
+				delete expectedTsconfig.files;
+
+				const tsconfig = parseTsconfig(fixture.getPath('tsconfig.json'));
+				expect(tsconfig).toStrictEqual(expectedTsconfig);
+			});
+		});
+
+		describe('rootDirs', ({ test }) => {
+			test('gets inherited with relative paths', async () => {
+				await using fixture = await createFixture({
+					project: {
+						src: { 'a.ts': '' },
+						generated: { 'b.ts': '' },
+						'tsconfig.json': createTsconfigJson({
+							compilerOptions: {
+								rootDirs: ['src', 'generated'],
+							},
+						}),
+					},
+					'tsconfig.json': createTsconfigJson({
+						extends: './project/tsconfig.json',
+					}),
+					'file.ts': '',
+				});
+
+				const expectedTsconfig = await getTscTsconfig(fixture.path);
+				delete expectedTsconfig.files;
+
+				const tsconfig = parseTsconfig(fixture.getPath('tsconfig.json'));
+				expect(tsconfig).toStrictEqual(expectedTsconfig);
+			});
+
+			test('resolves parent rootDirs with mixed paths', async () => {
+				await using fixture = await createFixture({
+					project: {
+						src: { 'a.ts': '' },
+						'tsconfig.json': createTsconfigJson({
+							compilerOptions: {
+								rootDirs: ['.', './types'],
+							},
+						}),
+					},
+					'tsconfig.json': createTsconfigJson({
+						extends: './project/tsconfig.json',
+					}),
+					'file.ts': '',
+				});
+
+				const expectedTsconfig = await getTscTsconfig(fixture.path);
+				delete expectedTsconfig.files;
+
+				const tsconfig = parseTsconfig(fixture.getPath('tsconfig.json'));
+				expect(tsconfig).toStrictEqual(expectedTsconfig);
+			});
+		});
+
+		describe('typeRoots', ({ test }) => {
+			test('gets inherited with relative paths', async () => {
+				await using fixture = await createFixture({
+					project: {
+						types: { 'index.d.ts': '' },
+						'tsconfig.json': createTsconfigJson({
+							compilerOptions: {
+								typeRoots: ['types'],
+							},
+						}),
+					},
+					'tsconfig.json': createTsconfigJson({
+						extends: './project/tsconfig.json',
+					}),
+					'file.ts': '',
+				});
+
+				const expectedTsconfig = await getTscTsconfig(fixture.path);
+				delete expectedTsconfig.files;
+
+				const tsconfig = parseTsconfig(fixture.getPath('tsconfig.json'));
+				expect(tsconfig).toStrictEqual(expectedTsconfig);
+			});
+
+			test('resolves parent typeRoots with multiple entries', async () => {
+				await using fixture = await createFixture({
+					project: {
+						types: { 'index.d.ts': '' },
+						'custom-types': { 'globals.d.ts': '' },
+						'tsconfig.json': createTsconfigJson({
+							compilerOptions: {
+								typeRoots: ['types', 'custom-types'],
+							},
+						}),
+					},
+					'tsconfig.json': createTsconfigJson({
+						extends: './project/tsconfig.json',
+					}),
+					'file.ts': '',
+				});
+
+				const expectedTsconfig = await getTscTsconfig(fixture.path);
+				delete expectedTsconfig.files;
+
+				const tsconfig = parseTsconfig(fixture.getPath('tsconfig.json'));
+				expect(tsconfig).toStrictEqual(expectedTsconfig);
+			});
+		});
+
+		describe('declarationDir', ({ test }) => {
+			test('gets inherited with relative path', async () => {
+				await using fixture = await createFixture({
+					'a/dep.json': createTsconfigJson({
+						compilerOptions: {
+							declaration: true,
+							declarationDir: 'types',
+						},
+					}),
+					'tsconfig.json': createTsconfigJson({
+						extends: './a/dep.json',
+					}),
+					'file.ts': '',
+				});
+
+				const expectedTsconfig = await getTscTsconfig(fixture.path);
+				delete expectedTsconfig.files;
+
+				/**
+				 * Same tsc bug as outDir — declarationDir from extended
+				 * tsconfig should be in exclude but tsc doesn't add it
+				 */
+				expectedTsconfig.exclude = ['a/types'];
+
+				const tsconfig = parseTsconfig(fixture.getPath('tsconfig.json'));
+				expect(tsconfig).toStrictEqual(expectedTsconfig);
+			});
+		});
+
 		test('nested extends', async () => {
 			await using fixture = await createFixture({
 				'file.ts': '',

--- a/tests/specs/parse-tsconfig/extends/resolves/relative-path.spec.ts
+++ b/tests/specs/parse-tsconfig/extends/resolves/relative-path.spec.ts
@@ -181,5 +181,65 @@ export default testSuite(({ describe }) => {
 			const tsconfig = parseTsconfig(fixture.getPath('tsconfig.json'));
 			expect(tsconfig).toStrictEqual(expectedTsconfig);
 		});
+
+		test('rootDir in extends', async () => {
+			await using fixture = await createFixture({
+				'a/dep.json': createTsconfigJson({
+					compilerOptions: {
+						rootDir: 'src',
+					},
+				}),
+				'tsconfig.json': createTsconfigJson({
+					extends: './a/dep.json',
+				}),
+				'file.ts': '',
+			});
+
+			const expectedTsconfig = await getTscTsconfig(fixture.path);
+			delete expectedTsconfig.files;
+
+			const tsconfig = parseTsconfig(fixture.getPath('tsconfig.json'));
+			expect(tsconfig).toStrictEqual(expectedTsconfig);
+		});
+
+		test('rootDirs in extends', async () => {
+			await using fixture = await createFixture({
+				'a/dep.json': createTsconfigJson({
+					compilerOptions: {
+						rootDirs: ['src', 'generated'],
+					},
+				}),
+				'tsconfig.json': createTsconfigJson({
+					extends: './a/dep.json',
+				}),
+				'file.ts': '',
+			});
+
+			const expectedTsconfig = await getTscTsconfig(fixture.path);
+			delete expectedTsconfig.files;
+
+			const tsconfig = parseTsconfig(fixture.getPath('tsconfig.json'));
+			expect(tsconfig).toStrictEqual(expectedTsconfig);
+		});
+
+		test('typeRoots in extends', async () => {
+			await using fixture = await createFixture({
+				'a/dep.json': createTsconfigJson({
+					compilerOptions: {
+						typeRoots: ['types'],
+					},
+				}),
+				'tsconfig.json': createTsconfigJson({
+					extends: './a/dep.json',
+				}),
+				'file.ts': '',
+			});
+
+			const expectedTsconfig = await getTscTsconfig(fixture.path);
+			delete expectedTsconfig.files;
+
+			const tsconfig = parseTsconfig(fixture.getPath('tsconfig.json'));
+			expect(tsconfig).toStrictEqual(expectedTsconfig);
+		});
 	});
 });


### PR DESCRIPTION
When a tsconfig extends another from a different directory, paths like baseUrl and outDir are already rewritten relative to the extending config. rootDir, rootDirs, typeRoots, and declarationDir were missing the same treatment, causing incorrect path resolution for inherited values.

Also normalize rootDirs/typeRoots values through normalizeRelativePath so non-${configDir} values get the ./ prefix matching tsc output.

reference: https://github.com/webpro-nl/knip/pull/1681