### PR TITLE
fix(parse-tsconfig): resolve extends dependencies of symlinked packages

### DIFF
--- a/src/parse-tsconfig/resolve-extends-path.ts
+++ b/src/parse-tsconfig/resolve-extends-path.ts
@@ -143,17 +143,11 @@ export const resolveExtendsPath = (
 		} catch {}
 	}
 
-	const nodeModulesPackagePath = path.join('node_modules', packageName);
-	const resolvedDirectoryPath = path.resolve(directoryPath);
-	let packagePath = findUp(resolvedDirectoryPath, nodeModulesPackagePath, cache);
-
-	if (!packagePath) {
-		const realDirectoryPath = realpath(cache, resolvedDirectoryPath);
-
-		if (realDirectoryPath !== resolvedDirectoryPath) {
-			packagePath = findUp(realDirectoryPath, nodeModulesPackagePath, cache);
-		}
-	}
+	const packagePath = findUp(
+		realpath(cache, path.resolve(directoryPath)),
+		path.join('node_modules', packageName),
+		cache,
+	);
 
 	if (!packagePath || !stat(cache, packagePath)!.isDirectory()) {
 		return;

--- a/src/parse-tsconfig/resolve-extends-path.ts
+++ b/src/parse-tsconfig/resolve-extends-path.ts
@@ -4,7 +4,7 @@ import { resolveExports } from 'resolve-pkg-maps';
 import type { PackageJson } from 'type-fest';
 import { findUp } from '../utils/find-up.js';
 import { readJsonc } from '../utils/read-jsonc.js';
-import { stat, exists } from '../utils/fs-cached.js';
+import { stat, exists, realpath } from '../utils/fs-cached.js';
 import type { Cache } from '../types.js';
 
 const getPnpApi = () => {
@@ -143,11 +143,21 @@ export const resolveExtendsPath = (
 		} catch {}
 	}
 
-	const packagePath = findUp(
-		path.resolve(directoryPath),
-		path.join('node_modules', packageName),
-		cache,
-	);
+	const nodeModulesPackagePath = path.join('node_modules', packageName);
+	const resolvedDirectoryPath = path.resolve(directoryPath);
+	let packagePath = findUp(resolvedDirectoryPath, nodeModulesPackagePath, cache);
+
+	/**
+	 * When the extending config is behind a symlink (e.g. pnpm's isolated
+	 * node_modules), its dependencies are only reachable from its real
+	 * location, so retry from there like Node.js module resolution does
+	 */
+	if (!packagePath) {
+		const realDirectoryPath = realpath(cache, resolvedDirectoryPath);
+		if (realDirectoryPath !== resolvedDirectoryPath) {
+			packagePath = findUp(realDirectoryPath, nodeModulesPackagePath, cache);
+		}
+	}
 
 	if (!packagePath || !stat(cache, packagePath)!.isDirectory()) {
 		return;

--- a/src/parse-tsconfig/resolve-extends-path.ts
+++ b/src/parse-tsconfig/resolve-extends-path.ts
@@ -143,15 +143,17 @@ export const resolveExtendsPath = (
 		} catch {}
 	}
 
-	const packagePath = findUp(
-		realpath(cache, path.resolve(directoryPath)),
+	const rawPackagePath = findUp(
+		path.resolve(directoryPath),
 		path.join('node_modules', packageName),
 		cache,
 	);
 
-	if (!packagePath || !stat(cache, packagePath)!.isDirectory()) {
+	if (!rawPackagePath || !stat(cache, rawPackagePath)!.isDirectory()) {
 		return;
 	}
+
+	const packagePath = realpath(cache, rawPackagePath);
 
 	const packageJsonPath = path.join(packagePath, PACKAGE_JSON);
 	if (exists(cache, packageJsonPath)) {

--- a/src/parse-tsconfig/resolve-extends-path.ts
+++ b/src/parse-tsconfig/resolve-extends-path.ts
@@ -147,13 +147,9 @@ export const resolveExtendsPath = (
 	const resolvedDirectoryPath = path.resolve(directoryPath);
 	let packagePath = findUp(resolvedDirectoryPath, nodeModulesPackagePath, cache);
 
-	/**
-	 * When the extending config is behind a symlink (e.g. pnpm's isolated
-	 * node_modules), its dependencies are only reachable from its real
-	 * location, so retry from there like Node.js module resolution does
-	 */
 	if (!packagePath) {
 		const realDirectoryPath = realpath(cache, resolvedDirectoryPath);
+
 		if (realDirectoryPath !== resolvedDirectoryPath) {
 			packagePath = findUp(realDirectoryPath, nodeModulesPackagePath, cache);
 		}

--- a/src/parse-tsconfig/resolve-extends-path.ts
+++ b/src/parse-tsconfig/resolve-extends-path.ts
@@ -149,7 +149,7 @@ export const resolveExtendsPath = (
 		cache,
 	);
 
-	if (!rawPackagePath || !stat(cache, rawPackagePath)!.isDirectory()) {
+	if (!rawPackagePath || !stat(cache, rawPackagePath)?.isDirectory()) {
 		return;
 	}
 

--- a/src/utils/fs-cached.ts
+++ b/src/utils/fs-cached.ts
@@ -37,5 +37,15 @@ const cacheFs = <MethodName extends keyof FsMethods>(
 export const exists = cacheFs('existsSync');
 export const readFile = cacheFs('readFileSync');
 export const stat = cacheFs('statSync');
-// Cast because inferring from the overloaded realpathSync yields string | Buffer
-export const realpath = cacheFs('realpathSync') as (cache: Cache | undefined, path: string) => string;
+
+const rawRealpath = cacheFs('realpathSync');
+
+export const realpath = (...[child, directory]: Parameters<typeof rawRealpath>): string => {
+	const path = rawRealpath(child, directory);
+
+	if (typeof path !== 'string') {
+		throw new TypeError(`Unexpected resolved path type for ${path} in ${directory}`);
+	}
+
+	return path;
+};

--- a/src/utils/fs-cached.ts
+++ b/src/utils/fs-cached.ts
@@ -37,3 +37,5 @@ const cacheFs = <MethodName extends keyof FsMethods>(
 export const exists = cacheFs('existsSync');
 export const readFile = cacheFs('readFileSync');
 export const stat = cacheFs('statSync');
+// Cast because inferring from the overloaded realpathSync yields string | Buffer
+export const realpath = cacheFs('realpathSync') as (cache: Cache | undefined, path: string) => string;

--- a/tests/specs/parse-tsconfig/extends/resolves/node-modules.spec.ts
+++ b/tests/specs/parse-tsconfig/extends/resolves/node-modules.spec.ts
@@ -442,6 +442,92 @@ export default testSuite('node_modules', ({ describe, test }) => {
 		expect(tsconfig).toStrictEqual(expectedTsconfig);
 	});
 
+	test('resolves dependency from the apparent location of a symlinked project directory', async () => {
+		await using fixture = await createFixture({
+			'real/project': {
+				'tsconfig.json': createTsconfigJson({
+					extends: 'dep',
+				}),
+				'file.ts': '',
+			},
+			apparent: {
+				'node_modules/dep/tsconfig.json': createTsconfigJson({
+					compilerOptions: {
+						jsx: 'react',
+						strict: true,
+					},
+				}),
+				project: ({ symlink }) => symlink('../real/project', 'dir'),
+			},
+		});
+
+		const expectedTsconfig = await getTscTsconfig(fixture.path, 'apparent/project');
+		delete expectedTsconfig.files;
+
+		const tsconfig = parseTsconfig(fixture.getPath('apparent/project/tsconfig.json'));
+
+		expect(tsconfig).toStrictEqual(expectedTsconfig);
+	});
+
+	test('prefers dependency at the apparent location of a symlinked project directory', async () => {
+		await using fixture = await createFixture({
+			real: {
+				'node_modules/dep/tsconfig.json': createTsconfigJson({
+					compilerOptions: {
+						jsx: 'preserve',
+					},
+				}),
+				project: {
+					'tsconfig.json': createTsconfigJson({
+						extends: 'dep',
+					}),
+					'file.ts': '',
+				},
+			},
+			apparent: {
+				'node_modules/dep/tsconfig.json': createTsconfigJson({
+					compilerOptions: {
+						jsx: 'react',
+					},
+				}),
+				project: ({ symlink }) => symlink('../real/project', 'dir'),
+			},
+		});
+
+		const expectedTsconfig = await getTscTsconfig(fixture.path, 'apparent/project');
+		delete expectedTsconfig.files;
+
+		const tsconfig = parseTsconfig(fixture.getPath('apparent/project/tsconfig.json'));
+
+		expect(tsconfig).toStrictEqual(expectedTsconfig);
+	});
+
+	test('does not resolve dependency from the apparent location of a symlinked package', async () => {
+		await using fixture = await createFixture({
+			'linked/shared-config/tsconfig.json': createTsconfigJson({
+				extends: 'dep',
+			}),
+			project: {
+				'node_modules/dep/tsconfig.json': createTsconfigJson({
+					compilerOptions: {
+						jsx: 'react',
+					},
+				}),
+				'node_modules/shared-config': ({ symlink }) => symlink('../../linked/shared-config', 'dir'),
+				'tsconfig.json': createTsconfigJson({
+					extends: 'shared-config',
+				}),
+				'file.ts': '',
+			},
+		});
+
+		const errorMessage = 'File \'dep\' not found';
+		await expect(
+			getTscTsconfig(fixture.path, 'project'),
+		).rejects.toThrow(errorMessage);
+		expect(() => parseTsconfig(fixture.getPath('project/tsconfig.json'))).toThrow(errorMessage);
+	});
+
 	describe('package.json#tsconfig', ({ test }) => {
 		test('package.json#tsconfig', async () => {
 			await using fixture = await createFixture({

--- a/tests/specs/parse-tsconfig/extends/resolves/node-modules.spec.ts
+++ b/tests/specs/parse-tsconfig/extends/resolves/node-modules.spec.ts
@@ -411,7 +411,7 @@ export default testSuite('node_modules', ({ describe, test }) => {
 								},
 							}),
 						},
-						'base-config': ({ symlink }) => symlink('../../base-config@1.0.0/node_modules/base-config'),
+						'base-config': ({ symlink }) => symlink('../../base-config@1.0.0/node_modules/base-config', 'dir'),
 					},
 					'base-config@1.0.0/node_modules/base-config': {
 						'package.json': createPackageJson({
@@ -426,7 +426,7 @@ export default testSuite('node_modules', ({ describe, test }) => {
 						}),
 					},
 				},
-				'shared-config': ({ symlink }) => symlink('./.pnpm/shared-config@1.0.0/node_modules/shared-config'),
+				'shared-config': ({ symlink }) => symlink('./.pnpm/shared-config@1.0.0/node_modules/shared-config', 'dir'),
 			},
 			'tsconfig.json': createTsconfigJson({
 				extends: 'shared-config',

--- a/tests/specs/parse-tsconfig/extends/resolves/node-modules.spec.ts
+++ b/tests/specs/parse-tsconfig/extends/resolves/node-modules.spec.ts
@@ -394,6 +394,54 @@ export default testSuite('node_modules', ({ describe, test }) => {
 		}
 	});
 
+	test('resolves dependency of symlinked package in pnpm-style node_modules', async () => {
+		await using fixture = await createFixture({
+			node_modules: {
+				'.pnpm': {
+					'shared-config@1.0.0/node_modules': {
+						'shared-config': {
+							'package.json': createPackageJson({
+								name: 'shared-config',
+								version: '1.0.0',
+							}),
+							'tsconfig.json': createTsconfigJson({
+								extends: 'base-config',
+								compilerOptions: {
+									jsx: 'react',
+								},
+							}),
+						},
+						'base-config': ({ symlink }) => symlink('../../base-config@1.0.0/node_modules/base-config'),
+					},
+					'base-config@1.0.0/node_modules/base-config': {
+						'package.json': createPackageJson({
+							name: 'base-config',
+							version: '1.0.0',
+						}),
+						'tsconfig.json': createTsconfigJson({
+							compilerOptions: {
+								strict: true,
+								allowJs: true,
+							},
+						}),
+					},
+				},
+				'shared-config': ({ symlink }) => symlink('./.pnpm/shared-config@1.0.0/node_modules/shared-config'),
+			},
+			'tsconfig.json': createTsconfigJson({
+				extends: 'shared-config',
+			}),
+			'file.ts': '',
+		});
+
+		const expectedTsconfig = await getTscTsconfig(fixture.path);
+		delete expectedTsconfig.files;
+
+		const tsconfig = parseTsconfig(fixture.getPath('tsconfig.json'));
+
+		expect(tsconfig).toStrictEqual(expectedTsconfig);
+	});
+
 	describe('package.json#tsconfig', ({ test }) => {
 		test('package.json#tsconfig', async () => {
 			await using fixture = await createFixture({


### PR DESCRIPTION
In pnpm's isolated node_modules layout, a config package is symlinked into the project's node_modules while its own dependencies are only reachable as siblings of its real location in the store. Walking up node_modules from the symlink path alone cannot find them, so a config package extending another config package failed with "File not found"
even though `tsc` resolves the same chain.