### PR TITLE
fix(files-matcher): resolve relative patterns against UNC roots

### DIFF
--- a/src/files-matcher.ts
+++ b/src/files-matcher.ts
@@ -6,7 +6,25 @@ import type { TsConfigResult, TsConfigJsonResolved } from './types.js';
 
 export type FileMatcher = (filePath: string) => (TsConfigJsonResolved | undefined);
 
-const { join: pathJoin } = path.posix;
+const { join: posixJoin } = path.posix;
+
+/**
+ * `path.posix.join` collapses the leading double slash of a UNC root
+ * (e.g. `//server/share` -> `/server/share`), but the file paths passed
+ * into the matcher keep both slashes, so resolved patterns would never match
+ * https://github.com/privatenumber/get-tsconfig/issues/133
+ */
+const pathJoin = (
+	basePath: string,
+	subpath: string,
+) => {
+	const joined = posixJoin(basePath, subpath);
+	return (
+		basePath.startsWith('//') && !joined.startsWith('//')
+			? `/${joined}`
+			: joined
+	);
+};
 
 const baseExtensions = {
 	ts: ['.ts', '.tsx', '.d.ts'],

--- a/tests/specs/create-files-matcher.ts
+++ b/tests/specs/create-files-matcher.ts
@@ -1334,4 +1334,78 @@ export default testSuite('createFilesMatcher', ({ describe }) => {
 			assertFilesMatch(matches, tsFiles);
 		});
 	});
+
+	// https://github.com/privatenumber/get-tsconfig/issues/133
+	describe('UNC paths', ({ test }) => {
+		const uncProjectPath = '//server/share/project';
+		const uncTsconfigPath = `${uncProjectPath}/tsconfig.json`;
+
+		test('default include', () => {
+			const tsconfig: TsConfigJsonResolved = {};
+			const matches = createFilesMatcher({
+				config: tsconfig,
+				path: uncTsconfigPath,
+			});
+
+			expect(matches(`${uncProjectPath}/index.ts`)).toBe(tsconfig);
+			expect(matches('//server/other-share/project/index.ts')).toBe(undefined);
+		});
+
+		test('relative include', () => {
+			const tsconfig: TsConfigJsonResolved = {
+				include: ['src'],
+			};
+			const matches = createFilesMatcher({
+				config: tsconfig,
+				path: uncTsconfigPath,
+			});
+
+			expect(matches(`${uncProjectPath}/src/index.ts`)).toBe(tsconfig);
+			expect(matches(`${uncProjectPath}/excluded/index.ts`)).toBe(undefined);
+		});
+
+		test('relative files', () => {
+			const tsconfig: TsConfigJsonResolved = {
+				files: ['src/index.ts'],
+			};
+			const matches = createFilesMatcher({
+				config: tsconfig,
+				path: uncTsconfigPath,
+			});
+
+			expect(matches(`${uncProjectPath}/src/index.ts`)).toBe(tsconfig);
+			expect(matches(`${uncProjectPath}/src/excluded.ts`)).toBe(undefined);
+		});
+
+		if (isWindows) {
+			test('matches tsc through a real UNC path', async () => {
+				const tsconfig: TsConfigJsonResolved = {
+					include: ['src'],
+				};
+
+				await using fixture = await createFixture({
+					'tsconfig.json': createTsconfigJson(tsconfig),
+					'src/index.ts': '',
+					'excluded/index.ts': '',
+				});
+
+				// C:\path -> \\localhost\C$\path
+				const tsconfigPath = fixture.getPath('tsconfig.json').replace(
+					/^(\w):/,
+					(_, driveLetter) => `\\\\localhost\\${driveLetter}$`,
+				);
+
+				const tsFiles = getTscMatchingFiles(tsconfigPath);
+				expect(tsFiles.length).toBe(1);
+
+				assertFilesMatch(
+					createFilesMatcher({
+						config: tsconfig,
+						path: tsconfigPath,
+					}),
+					tsFiles,
+				);
+			});
+		}
+	});
 });


### PR DESCRIPTION
fixes #133

## Problem

`createFilesMatcher` resolves relative `include` / `files` entries with `path.posix.join`, which collapses the leading double slash of a UNC root:

```js
path.posix.join('//server/share/project', 'src')
// -> '/server/share/project/src'   (one slash lost)
```

The file paths passed into the matcher keep both slashes (`slash('\\\\server\\share\\...')` -> `//server/share/...`), so under a UNC project every relative pattern misses and the matcher returns `undefined` for files tsc does include.

## Fix

Wrap the posix join so that when the base path starts with `//`, the slash that `join` collapsed is restored. Drive-letter and regular posix paths are unaffected. Both call sites go through the wrapper: pattern resolution and the implicit `**/*` append for directory includes.

## Tests

- String-level cases in a new `UNC paths` group (default include, relative `include`, relative `files`) — these fail without the fix and run on every platform, since the matcher is pure path-string logic.
- A Windows-only case that maps a real fixture through `\\\\localhost\\<drive>$\\...` and verifies the matcher against `tsc`'s own file list (`parseJsonConfigFileContent`), following the existing tsc-verification pattern.

`pnpm build && pnpm test`: 216 passed. `tsc --noEmit` clean; lint clean apart from the pre-existing complexity warning on `createFilesMatcher`.